### PR TITLE
add theta examples, fix season documentation

### DIFF
--- a/R/theta.R
+++ b/R/theta.R
@@ -95,7 +95,7 @@ specials_theta <- new_specials(
 #' \subsection{season}{
 #' The `season` special is used to specify the parameters of the seasonal adjustment via classical decomposition.
 #' \preformatted{
-#' window(period = NULL, method = c("multiplicative", "additive"))
+#' season(period = NULL, method = c("multiplicative", "additive"))
 #' }
 #'
 #' \tabular{ll}{
@@ -114,6 +114,21 @@ specials_theta <- new_specials(
 #' Hyndman, R.J., and Billah, B. (2003) Unmasking the Theta method.
 #' \emph{International J. Forecasting}, \bold{19}, 287-290.
 #' 
+#' @examples
+#' # Theta method with transform
+#' deaths <- as_tsibble(USAccDeaths)
+#' deaths %>%
+#'   model(theta = THETA(log(value))) %>%
+#'   forecast(h = "4 years") %>%
+#'   autoplot(deaths)
+#' 
+#' # Compare seasonal specifications
+#' library(tsibbledata)
+#' aus_retail %>%
+#'   filter(Industry == "Clothing retailing") %>%
+#'   model(theta_multiplicative = THETA(Turnover ~ season(method = "multiplicative")),
+#'         theta_additive = THETA(Turnover ~ season(method = "additive"))) %>%
+#'   accuracy()
 #' @author Rob J Hyndman, Mitchell O'Hara-Wild
 #' @export
 THETA <- function(formula, ...) {


### PR DESCRIPTION
This at least starts to address #286 , and fixes a problem where `window()` was still in the documentation, instead of `season()`.