### PR TITLE
Update more deprecated github actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,9 +28,9 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
https://github.com/tidyverts/fable/actions/runs/7721580515 shows that actions/checkout@v2 and r-lib/actions/setup-pandoc@v1 are deprecated.

This updates them.