### PR TITLE
Update required fabletools version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ URL: https://fable.tidyverts.org, https://github.com/tidyverts/fable
 BugReports: https://github.com/tidyverts/fable/issues
 Depends:
     R (>= 3.4.0),
-    fabletools (>= 0.3.0)
+    fabletools (>= 0.5.0)
 Imports:
     Rcpp (>= 0.11.0),
     rlang (>= 0.4.6),


### PR DESCRIPTION
Required for `IRF` methods:

https://github.com/tidyverts/fable/blob/70e55accfd1d0af30e75c3aef374bca535526381/NAMESPACE#L3-L6