### PR TITLE
feat: use cli for errors and messaging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,7 @@ Depends:
     R (>= 3.4.0),
     fabletools (>= 0.3.0)
 Imports:
+    cli,
     Rcpp (>= 0.11.0),
     rlang (>= 0.4.6),
     stats,

--- a/R/00_specials.R
+++ b/R/00_specials.R
@@ -13,7 +13,7 @@ model_xreg <- function(...) {
 }
 
 no_xreg <- function(...) {
-  abort("Exogenous regressors are not supported for this model type.")
+  cli::cli_abort("Exogenous regressors are not supported for this model type.")
 }
 
 trend <- function(x, knots = NULL, origin = NULL) {
@@ -91,10 +91,10 @@ fourier.tbl_ts <- function(x, period, K, origin = NULL) {
 
 fourier.numeric <- function(x, period, K, origin = NULL) {
   if (length(period) != length(K)) {
-    abort("Number of periods does not match number of orders")
+    cli::cli_abort("Number of periods does not match number of orders")
   }
   if (any(2 * K > period)) {
-    abort("K must be not be greater than period/2")
+    cli::cli_abort("{.arg K} must be not be greater than period/2")
   }
 
   fourier_exprs <- map2(

--- a/R/VARIMA.R
+++ b/R/VARIMA.R
@@ -3,7 +3,7 @@ train_varima <- function(.data, specials, identification = NULL, ...) {
   y <- invoke(cbind, lapply(unclass(.data)[measured_vars(.data)], as.double))
   
   if(any(colnames(specials$xreg[[1]]) != "(Intercept)")) {
-    stop("Exogenous regressors for VARIMA are not yet supported.")
+    cli::cli_abort("Exogenous regressors for VARIMA are not yet supported.")
   }
   
   p <- specials$pdq[[1]]$p
@@ -20,7 +20,7 @@ train_varima <- function(.data, specials, identification = NULL, ...) {
     }
   }
   
-  require_package("MTS")
+  check_installed("MTS")
   utils::capture.output(
     fit <- if (identification == "kronecker_indices") {
       MTS::Kronfit(
@@ -39,7 +39,7 @@ train_varima <- function(.data, specials, identification = NULL, ...) {
       )
     } else {
       if(length(p) != 1 || length(q) != 1) {
-        stop("Model selection is not yet supported, please specify `p` and `q` exactly.")
+        cli::cli_abort("Model selection is not yet supported, please specify {.arg p} and {.arg q} exactly.")
       }
       MTS::VARMA(
         yd,
@@ -72,7 +72,7 @@ specials_varima <- new_specials(
     as.list(environment())
   },
   PDQ = function(P, D, Q, period = NULL) {
-    stop("Seasonal VARIMA models are not yet supported.")
+    cli::cli_abort("Seasonal VARIMA models are not yet supported.")
   },
   common_xregs,
   xreg = special_xreg(default_intercept = TRUE),

--- a/R/ar.R
+++ b/R/ar.R
@@ -72,7 +72,7 @@ AR <- function(formula, ic = c("aicc", "aic", "bic"), ...) {
 specials_ar <- new_specials(
   order = function(p = 0:15, fixed = list()) {
     if (any(p < 0)) {
-      warn("The AR order must be non-negative. Only non-negative orders will be considered.")
+      cli::cli_warn("The AR order must be non-negative. Only non-negative orders will be considered.")
       p <- p[p >= 0]
     }
     list(p = p, fixed = fixed)
@@ -158,9 +158,9 @@ estimate_ar <- function(x, p, xreg, constant, fixed) {
   XX <- t(X_est) %*% X_est
   rank <- qr(XX)$rank
   if (rank != nrow(XX)) {
-    warning(paste("model order: ", p, "singularities in the computation of the projection matrix", 
-                  "results are only valid up to model order", 
-                  p - 1L), domain = NA)
+    cli::cli_warn(
+      "model order: {p} singularities in the computation of the projection matrix results are only valid up to model order {p - 1L}"
+    )
     return(NULL)
   }
   P <- if (ncol(XX) > 0) 

--- a/R/checks.R
+++ b/R/checks.R
@@ -1,19 +1,19 @@
 check_gaps <- function(x) {
   if (any(tsibble::has_gaps(x)[[".gaps"]])) {
-    abort(sprintf("%s contains implicit gaps in time. You should check your data and convert implicit gaps into explicit missing values using `tsibble::fill_gaps()` if required.", deparse(substitute(x))))
+    cli::cli_abort(sprintf("%s contains implicit gaps in time. You should check your data and convert implicit gaps into explicit missing values using {.fn tsibble::fill_gaps} if required.", deparse(substitute(x))))
   }
 }
 
 check_regular <- function(x) {
   if (!is_regular(x)) {
-    abort(sprintf("%s is an irregular time series, which this model does not support. You should consider if your data can be made regular, and use `tsibble::update_tsibble(%s, regular = TRUE)` if appropriate.", deparse(substitute(x)), deparse(substitute(x))))
+    cli::cli_abort(sprintf("%s is an irregular time series, which this model does not support. You should consider if your data can be made regular, and use {.fn tsibble::update_tsibble(%s, regular = TRUE)} if appropriate.", deparse(substitute(x)), deparse(substitute(x))))
   }
 }
 
 check_ordered <- function(x) {
   if (!is_ordered(x)) {
-    abort(sprintf(
-      "%s is an unordered time series. To use this model, you first must sort the data in time order using `dplyr::arrange(%s, %s)`",
+    cli::cli_abort(sprintf(
+      "%s is an unordered time series. To use this model, you first must sort the data in time order using {.fn dplyr::arrange(%s, %s)}",
       deparse(substitute(x)), paste(c(deparse(substitute(x)), key_vars(x)), collapse = ", "), index_var(x)
     ))
   }
@@ -24,6 +24,6 @@ all_tsbl_checks <- function(.data) {
   check_regular(.data)
   check_ordered(.data)
   if (NROW(.data) == 0) {
-    abort("There is no data to model. Please provide a dataset with at least one observation.")
+    cli::cli_abort("There is no data to model. Please provide a dataset with at least one observation.")
   }
 }

--- a/R/croston.R
+++ b/R/croston.R
@@ -99,10 +99,10 @@ CROSTON <- function(
 specials_croston <- new_specials(
   demand = function(initial = NULL, param = NULL, param_range = c(0, 1)) {
     if (!is.null(initial) && initial < 0) {
-      abort("The initial demand for Croston's method must be non-negative")
+      cli::cli_abort("The initial demand for Croston's method must be non-negative")
     }
     if (param_range[1] > param_range[2]) {
-      rlang::abort("Lower param limits must be less than upper limits")
+      cli::cli_abort("Lower param limits must be less than upper limits")
     }
 
     as.list(environment())
@@ -111,11 +111,11 @@ specials_croston <- new_specials(
     method <- match.arg(method)
 
     if (!is.null(initial) && initial < 1) {
-      abort("The initial interval for Croston's method must be greater than (or equal to) 1.")
+      cli::cli_abort("The initial interval for Croston's method must be greater than (or equal to) 1.")
     }
 
     if (param_range[1] > param_range[2]) {
-      rlang::abort("Lower param limits must be less than upper limits")
+      cli::cli_abort("Lower param limits must be less than upper limits")
     }
 
     as.list(environment())
@@ -125,7 +125,7 @@ specials_croston <- new_specials(
 
 train_croston <- function(.data, specials, opt_crit = "mse", type = "croston", ...) {
   if (length(measured_vars(.data)) > 1) {
-    abort("Only univariate responses are supported by Croston's method.")
+    cli::cli_abort("Only univariate responses are supported by Croston's method.")
   }
 
   # Get response
@@ -133,13 +133,13 @@ train_croston <- function(.data, specials, opt_crit = "mse", type = "croston", .
 
   # Check data
   if (any(y < 0)) {
-    abort("All observations must be non-negative for Croston's method.")
+    cli::cli_abort("All observations must be non-negative for Croston's method.")
   }
 
   non_zero <- which(y != 0)
 
   if (length(non_zero) < 2) {
-    abort("At least two non-zero values are required to use Croston's method.")
+    cli::cli_abort("At least two non-zero values are required to use Croston's method.")
   }
 
   # Get specials

--- a/R/ets.R
+++ b/R/ets.R
@@ -1,14 +1,14 @@
 train_ets <- function(.data, specials, opt_crit,
                       nmse, bounds, ic, restrict = TRUE, ...) {
   if (length(measured_vars(.data)) > 1) {
-    abort("Only univariate responses are supported by ETS.")
+    cli::cli_abort("Only univariate responses are supported by ETS.")
   }
 
   # Rebuild `ets` arguments
   ets_spec <- specials[c("error", "trend", "season")]
   map(ets_spec, function(.x) {
     if (length(.x) > 1) {
-      abort("Only one special of each type is allowed for ETS.")
+      cli::cli_abort("Only one special of each type is allowed for ETS.")
     }
   })
   ets_spec <- unlist(ets_spec, recursive = FALSE)
@@ -18,7 +18,7 @@ train_ets <- function(.data, specials, opt_crit,
   idx <- unclass(.data)[[index_var(.data)]]
 
   if (any(is.na(y))) {
-    abort("ETS does not support missing values.")
+    cli::cli_abort("ETS does not support missing values.")
   }
 
   # Build possible models
@@ -47,7 +47,7 @@ train_ets <- function(.data, specials, opt_crit,
   }
 
   if (NROW(model_opts) == 0) {
-    abort("No valid ETS models have been allowed. Consider allowing different (more stable) models, or enabling the restricted models with `restrict = FALSE`.")
+    cli::cli_abort("No valid ETS models have been allowed. Consider allowing different (more stable) models, or enabling the restricted models with {.code restrict = FALSE}.")
   }
 
   # Find best model
@@ -78,7 +78,7 @@ train_ets <- function(.data, specials, opt_crit,
   ic <- pmap_dbl(model_opts, compare_ets)
 
   if (is.null(best)) {
-    abort(last_error$message)
+    cli::cli_abort(last_error$message)
   }
 
   best_spec <- model_opts[which.min(ic), ]
@@ -114,7 +114,7 @@ train_ets <- function(.data, specials, opt_crit,
 specials_ets <- new_specials(
   error = function(method = c("A", "M")) {
     if (!all(is.element(method, c("A", "M")))) {
-      stop("Invalid error type")
+      cli::cli_abort("Invalid error type")
     }
     list(method = method)
   },
@@ -123,16 +123,16 @@ specials_ets <- new_specials(
                    beta = NULL, beta_range = c(1e-04, 0.9999),
                    phi = NULL, phi_range = c(0.8, 0.98)) {
     if (!all(is.element(method, c("N", "A", "Ad", "M", "Md")))) {
-      stop("Invalid trend type")
+      cli::cli_abort("Invalid trend type")
     }
     if (alpha_range[1] > alpha_range[2]) {
-      abort("Lower alpha limits must be less than upper limits")
+      cli::cli_abort("Lower alpha limits must be less than upper limits")
     }
     if (beta_range[1] > beta_range[2]) {
-      abort("Lower beta limits must be less than upper limits")
+      cli::cli_abort("Lower beta limits must be less than upper limits")
     }
     if (phi_range[1] > phi_range[2]) {
-      abort("Lower phi limits must be less than upper limits")
+      cli::cli_abort("Lower phi limits must be less than upper limits")
     }
     if(!is.null(alpha)) alpha_range <- rep(alpha, 2)
     if(!is.null(beta)) beta_range <- rep(beta, 2)
@@ -147,10 +147,10 @@ specials_ets <- new_specials(
   season = function(method = c("N", "A", "M"), period = NULL,
                     gamma = NULL, gamma_range = c(1e-04, 0.9999)) {
     if (!all(is.element(method, c("N", "A", "M")))) {
-      abort("Invalid season type")
+      cli::cli_abort("Invalid season type")
     }
     if (gamma_range[1] > gamma_range[2]) {
-      abort("Lower gamma limits must be less than upper limits")
+      cli::cli_abort("Lower gamma limits must be less than upper limits")
     }
     if(!is.null(gamma)) gamma_range <- rep(gamma, 2)
 
@@ -160,14 +160,14 @@ specials_ets <- new_specials(
     }
     if (m > 24) {
       if (!is.element("N", method)) {
-        abort("Seasonal periods (`period`) of length greather than 24 are not supported by ETS.")
+        cli::cli_abort("Seasonal periods ({.arg period}) of length greather than 24 are not supported by ETS.")
       } else if (length(method) > 1) {
-        warn("Seasonal periods (`period`) of length greather than 24 are not supported by ETS. Seasonality will be ignored.")
+        cli::cli_warn("Seasonal periods ({.arg period}) of length greather than 24 are not supported by ETS. Seasonality will be ignored.")
         method <- "N"
       }
     }
     if (is_empty(method)) {
-      abort("A seasonal ETS model cannot be used for this data.")
+      cli::cli_abort("A seasonal ETS model cannot be used for this data.")
     }
     list(method = method, gamma = gamma, gamma_range = gamma_range, period = m)
   },
@@ -362,14 +362,14 @@ forecast.ETS <- function(object, new_data, specials = NULL, simulate = FALSE, bo
 #' @export
 generate.ETS <- function(x, new_data, specials, bootstrap = FALSE, ...) {
   if (!is_regular(new_data)) {
-    abort("Simulation new_data must be regularly spaced")
+    cli::cli_abort("Simulation new_data must be regularly spaced")
   }
 
   start_idx <- min(new_data[[index_var(new_data)]])
   start_pos <- match(start_idx - default_time_units(interval(new_data)), x$states[[index_var(x$states)]])
 
   if (is.na(start_pos)) {
-    abort("The first observation index of simulation data must be within the model's training set.")
+    cli::cli_abort("The first observation index of simulation data must be within the model's training set.")
   }
 
   initstate <- as.numeric(x$states[start_pos, measured_vars(x$states)])
@@ -414,7 +414,7 @@ generate.ETS <- function(x, new_data, specials, bootstrap = FALSE, ...) {
     )[[11]])
   
   if (is.na(result[[".sim"]][1])) {
-    stop("Problem with multiplicative damped trend")
+    cli::cli_abort("Problem with multiplicative damped trend")
   }
 
   result

--- a/R/etsmodel.R
+++ b/R/etsmodel.R
@@ -46,7 +46,7 @@ etsmodel <- function(y, m, errortype, trendtype, seasontype, damped,
   }
 
   if (!check.param(alpha, beta, gamma, phi, lower, upper, bounds, m)) {
-    abort(sprintf(
+    cli::cli_abort(sprintf(
       "Parameters out of range for ETS(%s,%s%s,%s) model",
       errortype, trendtype, ifelse(damped, "d", ""), seasontype
     ))
@@ -61,7 +61,7 @@ etsmodel <- function(y, m, errortype, trendtype, seasontype, damped,
 
   np <- length(par)
   if (np >= length(y) - 1) { # Not enough data to continue
-    abort("Not enough data to estimate this ETS model.")
+    cli::cli_abort("Not enough data to estimate this ETS model.")
   }
 
   env <- etsTargetFunctionInit(
@@ -161,12 +161,12 @@ etsTargetFunctionInit <- function(par, y, nstate, errortype, trendtype, seasonty
   names(par.noopt) <- pnames2
   alpha <- c(par["alpha"], par.noopt["alpha"])["alpha"]
   if (is.na(alpha)) {
-    stop("alpha problem!")
+    cli::cli_abort("alpha problem!")
   }
   if (trendtype != "N") {
     beta <- c(par["beta"], par.noopt["beta"])["beta"]
     if (is.na(beta)) {
-      stop("beta Problem!")
+      cli::cli_abort("beta Problem!")
     }
   }
   else {
@@ -175,7 +175,7 @@ etsTargetFunctionInit <- function(par, y, nstate, errortype, trendtype, seasonty
   if (seasontype != "N") {
     gamma <- c(par["gamma"], par.noopt["gamma"])["gamma"]
     if (is.na(gamma)) {
-      stop("gamma Problem!")
+      cli::cli_abort("gamma Problem!")
     }
   }
   else {
@@ -185,7 +185,7 @@ etsTargetFunctionInit <- function(par, y, nstate, errortype, trendtype, seasonty
   if (damped) {
     phi <- c(par["phi"], par.noopt["phi"])["phi"]
     if (is.na(phi)) {
-      stop("phi Problem!")
+      cli::cli_abort("phi Problem!")
     }
   }
   else {
@@ -259,7 +259,7 @@ initparam <- function(alpha, beta, gamma, phi, trendtype, seasontype, damped, lo
     lower[1L:3L] <- 0
     upper[1L:3L] <- 1e-3
   } else if (any(lower > upper)) {
-    stop("Inconsistent parameter boundaries")
+    cli::cli_abort("Inconsistent parameter boundaries")
   }
 
   # Select alpha
@@ -344,7 +344,7 @@ initstate <- function(y, m, trendtype, seasontype) {
     # Do decomposition
     n <- length(y)
     if (n < 4) {
-      stop("You've got to be joking (not enough data).")
+      cli::cli_abort("You've got to be joking (not enough data).")
     } else if (n < 3 * m) # Fit simple Fourier model.
       {
         fouriery <- as.matrix(fourier(seq_along(y), m, 1))

--- a/R/lagwalk.R
+++ b/R/lagwalk.R
@@ -1,13 +1,13 @@
 train_lagwalk <- function(.data, specials, ...) {
   if (length(measured_vars(.data)) > 1) {
-    abort("Only univariate responses are supported by lagwalks.")
+    cli::cli_abort("Only univariate responses are supported by lagwalks.")
   }
   
   y <- unclass(.data)[[measured_vars(.data)]]
   n <- length(y)
 
   if (all(is.na(y))) {
-    abort("All observations are missing, a model cannot be estimated without data.")
+    cli::cli_abort("All observations are missing, a model cannot be estimated without data.")
   }
 
   drift <- specials$drift[[1]][[1]] %||% FALSE
@@ -128,7 +128,7 @@ RW <- function(formula, ...) {
           lag <- 1
         }
         if (!rlang::is_integerish(lag)) {
-          warn("Non-integer lag orders for random walk models are not supported. Rounding to the nearest integer.")
+          cli::cli_warn("Non-integer lag orders for random walk models are not supported. Rounding to the nearest integer.")
           lag <- round(lag)
         }
         get_frequencies(lag, self$data, .auto = "smallest")
@@ -167,10 +167,10 @@ SNAIVE <- function(formula, ...) {
       lag = function(lag = NULL) {
         lag <- get_frequencies(lag, self$data, .auto = "smallest")
         if (lag == 1) {
-          abort("Non-seasonal model specification provided, use RW() or provide a different lag specification.")
+          cli::cli_abort("Non-seasonal model specification provided, use {.fn RW} or provide a different lag specification.")
         }
         if (!rlang::is_integerish(lag)) {
-          warn("Non-integer lag orders for random walk models are not supported. Rounding to the nearest integer.")
+          cli::cli_warn("Non-integer lag orders for random walk models are not supported. Rounding to the nearest integer.")
           lag <- round(lag)
         }
         lag
@@ -246,7 +246,7 @@ forecast.RW <- function(object, new_data, specials = NULL, simulate = FALSE, boo
 #' @export
 generate.RW <- function(x, new_data, bootstrap = FALSE, ...) {
   if (!is_regular(new_data)) {
-    abort("Simulation new_data must be regularly spaced")
+    cli::cli_abort("Simulation new_data must be regularly spaced")
   }
 
   lag <- x$lag
@@ -263,7 +263,7 @@ generate.RW <- function(x, new_data, bootstrap = FALSE, ...) {
   future <- fits[start_pos + seq_len(lag) - 1]
 
   if (any(is.na(future))) {
-    abort("The first lag window for simulation must be within the model's training set.")
+    cli::cli_abort("The first lag window for simulation must be within the model's training set.")
   }
 
   if (!(".innov" %in% names(new_data))) {

--- a/R/lm.R
+++ b/R/lm.R
@@ -272,7 +272,7 @@ forecast.TSLM <- function(object, new_data, specials = NULL, bootstrap = FALSE,
   xreg <- specials$xreg[[1]]
 
   if (rank < ncol(xreg)) {
-    warn("prediction from a rank-deficient fit may be misleading")
+    cli::cli_warn("prediction from a rank-deficient fit may be misleading")
   }
 
   # Intervals

--- a/R/mean.R
+++ b/R/mean.R
@@ -1,13 +1,13 @@
 #' @importFrom stats sd
 train_mean <- function(.data, specials, ...) {
   if (length(measured_vars(.data)) > 1) {
-    abort("Only univariate responses are supported by MEAN.")
+    cli::cli_abort("Only univariate responses are supported by MEAN.")
   }
 
   y <- unclass(.data)[[measured_vars(.data)]]
 
   if (all(is.na(y))) {
-    abort("All observations are missing, a model cannot be estimated without data.")
+    cli::cli_abort("All observations are missing, a model cannot be estimated without data.")
   }
 
   n <- length(y)
@@ -287,10 +287,10 @@ refit.model_mean <- function(object, new_data, specials = NULL, reestimate = FAL
   y <- unclass(new_data)[[measured_vars(new_data)]]
   
   if (all(is.na(y))) {
-    abort("All new observations are missing, model cannot be applied.")
+    cli::cli_abort("All new observations are missing, model cannot be applied.")
   }
 
-  if (!is_null(specials$window)) warn("A rolling mean model cannot be refitted, the most recent mean from the fitted model will be used as a fixed estimate of the mean.")
+  if (!is_null(specials$window)) cli::cli_warn("A rolling mean model cannot be refitted, the most recent mean from the fitted model will be used as a fixed estimate of the mean.")
   
   n <- length(y)
 

--- a/R/theta.R
+++ b/R/theta.R
@@ -1,14 +1,14 @@
 #' @importFrom stats sd
 train_theta <- function(.data, specials, ...) {
   if (length(measured_vars(.data)) > 1) {
-    abort("Only univariate responses are supported by the Theta method")
+    cli::cli_abort("Only univariate responses are supported by the Theta method")
   }
   
   y <- unclass(.data)[[measured_vars(.data)]]
   n <- length(y)
   
   if (all(is.na(y))) {
-    abort("All observations are missing, a model cannot be estimated without data.")
+    cli::cli_abort("All observations are missing, a model cannot be estimated without data.")
   }
   
   # Check seasonality
@@ -28,7 +28,7 @@ train_theta <- function(.data, specials, ...) {
   if (m > 1L) {
     dcmp <- stats::decompose(y, type = specials$season[[1]]$method)
     if (any(abs(dcmp$seasonal) < 1e-4)) {
-      warning("Seasonal indexes equal to zero. Using non-seasonal Theta method")
+      cli::cli_warn("Seasonal indexes equal to zero. Using non-seasonal Theta method")
     } else {
       y_sa <- if(dcmp$type == "additive") dcmp$x - dcmp$seasonal else dcmp$x / dcmp$seasonal
     }
@@ -146,7 +146,7 @@ THETA <- function(formula, ...) {
 #' @export
 forecast.fable_theta <- function(object, new_data, specials = NULL, bootstrap = FALSE, times = 5000, ...) {
   if (bootstrap) {
-    abort("Bootstrapped forecasts are not yet supported for the Theta method.")
+    cli::cli_abort("Bootstrapped forecasts are not yet supported for the Theta method.")
   }
   h <- NROW(new_data)
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,17 +6,9 @@ is.constant <- function(x) {
 
 assignSpecials <- function(x, env = caller_env()) {
   imap(x, function(.x, nm) {
-    if (length(.x) > 1) warn(sprintf("Only one special for `%s` is allowed, defaulting to the first usage", nm))
+    if (length(.x) > 1) cli::cli_warn("Only one special for {.code {nm}} is allowed, defaulting to the first usage")
     imap(.x[[1]], function(.x, .y) assign(.y, .x, envir = env))
   })
-}
-
-require_package <- function(pkg) {
-  if (!requireNamespace(pkg, quietly = TRUE)) {
-    abort(
-      sprintf('The `%s` package must be installed to use this functionality. It can be installed with install.packages("%s")', pkg, pkg)
-    )
-  }
 }
 
 `%||%` <- function(x, y) if (is_null(x)) y else x

--- a/R/var.R
+++ b/R/var.R
@@ -84,7 +84,7 @@ estimate_var <- function(y, p, xreg, constant) {
 specials_var <- new_specials(
   AR = function(p = 0:5) {
     if (any(p < 0)) {
-      warn("The AR order must be non-negative. Only non-negative orders will be considered.")
+      cli::cli_warn("The AR order must be non-negative. Only non-negative orders will be considered.")
       p <- p[p >= 0]
     }
     list(p = p)
@@ -200,7 +200,7 @@ VAR <- function(formula, ic = c("aicc", "aic", "bic"), ...) {
 forecast.VAR <- function(object, new_data = NULL, specials = NULL,
                          bootstrap = FALSE, times = 5000, ...) {
   if (bootstrap) {
-    abort("Bootstrapped forecasts for VARs are not yet implemented.")
+    cli::cli_abort("Bootstrapped forecasts for VARs are not yet implemented.")
   }
 
   h <- NROW(new_data)

--- a/R/vecm.R
+++ b/R/vecm.R
@@ -130,7 +130,7 @@ estimate_vecm <- function(y, p, sr_xreg, constant, r, ...) {
 specials_vecm <- new_specials(
   AR = function(p = 0:5) {
     if (any(p < 0)) {
-      warn("The AR order must be non-negative. Only non-negative orders will be considered.")
+      cli::cli_warn("The AR order must be non-negative. Only non-negative orders will be considered.")
       p <- p[p >= 0]
     }
     list(p = p)


### PR DESCRIPTION
* migrate base R and rlang to use cli for errors and warnings
* replace own require package function for rlang

There is most likely more potential for using inline styling or additional removal of `sprintf()` for the glue syntax inside the cli calls.